### PR TITLE
Packaging cross tools for AMD architectures

### DIFF
--- a/build/compiler.py
+++ b/build/compiler.py
@@ -154,8 +154,7 @@ class CompilerQt5(Builder):
             'Sysroot = {sysroot}\n' \
             'Prefix = {qt5_install_prefix}\n' \
             'HostPrefix= {sysroot}/{qt5_install_prefix}\n' \
-            'Binaries = {qt5_cross_binaries}\n' \
-            'HostBinaries = {qt5_cross_binaries}\n'.format(**self.config)
+            'HostBinaries = {qt5_install_prefix}/{qt5_cross_binaries}\n'.format(**self.config)
 
         if self.cross:
             command='cd {sources_directory} && sudo make install && ' \

--- a/qt5-build
+++ b/qt5-build
@@ -145,6 +145,7 @@ if __name__ == '__main__':
                                    packager.config['qt5_install_prefix'],
                                    packager.config['qt5_debian_version'],
                                    packager.config['qt5_cross_binaries'],
+                                   '{rpi_tools}/{xgcc_path64}'.format(**packager.config).rstrip('/bin'),
                                    dry_run=True if args['--dry-run'] else False)
         elif args['native-tools']:
             native_tools.pack_tools(packager.config['sysroot'],


### PR DESCRIPTION
This changeset does:
* build the cross tools package for AMD architectures
* includes a qt.conf file to find qt5 libraries inside the sysroot
* incorporates the official raspbian cross compiler for x86_64
